### PR TITLE
Publish MCP Server Alpha version

### DIFF
--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcontextprotocol.io/introduction) for managing context between large language models (LLMs) and external systems. In this package, we provide an installer as well as an MCP Server for [Chargebee](https://chargebee.com).
+Model Context Protocol (MCP) is a new, [standardized protocol](https://modelcontextprotocol.io/introduction) for managing context between large language models (LLMs) and external systems. In this package, we provide an installer as well as an MCP Server for [Chargebee](https://chargebee.com).
 
 This enables AI agents to generate integration code and answer your product queries using natural language in tools like Cursor IDE, Claude Desktop, or any MCP client.
 
@@ -113,4 +113,4 @@ export CHARGEBEE_TELEMETRY_DISABLED=1
 
 ## License
 
-[MIT](LICENSE)
+[MIT](https://github.com/chargebee/agentkit/blob/develop/LICENSE)

--- a/modelcontextprotocol/package.json
+++ b/modelcontextprotocol/package.json
@@ -6,7 +6,9 @@
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"bin": "dist/index.js",
+	"bin": {
+		"mcp": "dist/index.js"
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/modelcontextprotocol/package.json
+++ b/modelcontextprotocol/package.json
@@ -1,17 +1,19 @@
 {
-	"name": "@chargebee/mcp-dev",
-	"version": "0.0.1",
+	"name": "@chargebee/mcp",
+	"version": "0.0.1-alpha.2",
 	"description": "MCP server for interacting with Chargebee",
 	"type": "module",
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"bin": "dist/index.js",
+	"publishConfig": {
+		"access": "public"
+	},
 	"files": [
 		"dist",
 		"README.md"
 	],
-	"access": "private",
 	"scripts": {
 		"build": "cross-env AGENTKIT_BASE_URL=https://agentkit.ai.localcblabs.com tsup",
 		"postbuild": "shx chmod +x dist/*.js",
@@ -30,7 +32,7 @@
 		"node": ">=18"
 	},
 	"bugs": {
-		"url": "http://support.chargebee.com",
+		"url": "https://github.com/chargebee/agentkit/issues/new",
 		"email": "support@chargebee.com"
 	},
 	"devDependencies": {

--- a/modelcontextprotocol/package.json
+++ b/modelcontextprotocol/package.json
@@ -1,14 +1,12 @@
 {
 	"name": "@chargebee/mcp",
-	"version": "0.0.1-alpha.2",
+	"version": "0.0.1-alpha.5",
 	"description": "MCP server for interacting with Chargebee",
 	"type": "module",
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"bin": {
-		"mcp": "dist/index.js"
-	},
+	"bin": "dist/index.js",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/modelcontextprotocol/src/index.ts
+++ b/modelcontextprotocol/src/index.ts
@@ -84,9 +84,6 @@ function handleError(error: any) {
 	process.exit(1);
 }
 
-// Only run the main function if this is the main module
-if (import.meta.url === `file://${process.argv[1]}`) {
-	main().catch((error) => {
-		handleError(error);
-	});
-}
+main().catch((error) => {
+	handleError(error);
+});


### PR DESCRIPTION
- Changed package name from @chargebee/mcp-dev to @chargebee/mcp
- Updated version to 0.0.1-alpha.2
- Added publishConfig for public access
- Updated bugs URL in package.json to point to GitHub issues
- Updated license link in README.md to point to the correct GitHub location